### PR TITLE
Implement Delete Merged Action

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -69,8 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
-      - name: Delete branch
-        uses: dawidd6/action-delete-branch@v3
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branches: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
This PR replaces the current branch deletion action with SvanBoxel/delete-merged-branch from GitHub Marketplace. This action will automatically delete branches after they've been merged.