### PR TITLE
fix: use GitHub CLI for creating releases

### DIFF
--- a/.github/workflows/app-release-trigger.yml
+++ b/.github/workflows/app-release-trigger.yml
@@ -179,36 +179,51 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check_charts.outputs.charts_exist == 'true' && steps.create_tag.outputs.tag_verified == 'true'
-        uses: softprops/action-gh-release@v2.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
-        with:
-          tag_name: ${{ steps.parse.outputs.tag_name }}
-          name: Release ${{ steps.parse.outputs.tag_name }}
-          files: |
-            dist/fastapi-dev/*.tgz
-            dist/fastapi-staging/*.tgz
-            dist/fastapi-prod/*.tgz
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ github.event.client_payload.environment == 'stg' }}
-          body: |
-            ## Environment-specific Helm Charts
+        run: |
+          # Use gh CLI to create a release
+          echo "Creating GitHub release for tag ${{ steps.parse.outputs.tag_name }}..."
 
-            This release includes Helm charts for the following environments:
-            - Development (using staging images)
-            - Staging
-            - Production
+          # Install GitHub CLI if not already installed
+          if ! command -v gh &> /dev/null; then
+            echo "Installing GitHub CLI..."
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install gh -y
+          fi
 
-            ### Version Information
-            - Semantic Version for Helm: ${{ steps.parse.outputs.version }}
-            - Environment: ${{ steps.parse.outputs.environment }}
-            - Original Version: ${{ steps.parse.outputs.raw_version }}
-            - Git Hash: ${{ steps.parse.outputs.git_hash }}
+          # Authenticate with GitHub CLI
+          echo "${{ secrets.MACHINE_USER_TOKEN }}" | gh auth login --with-token
 
-            ### Image Tags
-            - Dev/Staging: ${{ steps.parse.outputs.version }}-stg
-            - Production: ${{ steps.parse.outputs.version }}
+          # Create release notes file
+          cat > release_notes.md << EOF
+          ## Environment-specific Helm Charts
+
+          This release includes Helm charts for the following environments:
+          - Development (using staging images)
+          - Staging
+          - Production
+
+          ### Version Information
+          - Semantic Version for Helm: ${{ steps.parse.outputs.version }}
+          - Environment: ${{ steps.parse.outputs.environment }}
+          - Original Version: ${{ steps.parse.outputs.raw_version }}
+          - Git Hash: ${{ steps.parse.outputs.git_hash }}
+
+          ### Image Tags
+          - Dev/Staging: ${{ steps.parse.outputs.version }}-stg
+          - Production: ${{ steps.parse.outputs.version }}
+          EOF
+
+          # Create the release
+          gh release create "${{ steps.parse.outputs.tag_name }}" \
+            --title "Release ${{ steps.parse.outputs.tag_name }}" \
+            --notes-file release_notes.md \
+            --generate-notes \
+            ${{ github.event.client_payload.environment == 'stg' && '--prerelease' || '' }} \
+            dist/fastapi-dev/*.tgz dist/fastapi-staging/*.tgz dist/fastapi-prod/*.tgz
+
+          echo "✅ GitHub release created successfully!"
 
 
       - name: Debug Release Creation

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -298,31 +298,40 @@ jobs:
 
       - name: Create GitHub Release (if not triggered by release)
         if: ${{ github.event_name != 'release' }}
-        uses: softprops/action-gh-release@v2.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
-        with:
-          tag_name: ${{ steps.process-tag.outputs.tag_name }}
-          name: Release ${{ steps.process-tag.outputs.tag_name }}
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ steps.vars.outputs.env == 'staging' }}
-          body: |
-            ## Helm Chart Update
+        run: |
+          # Use gh CLI to create a release
+          echo "Creating GitHub release for tag ${{ steps.process-tag.outputs.tag_name }}..."
 
-            This release updates the Helm charts for the **${{ steps.vars.outputs.env }}** environment.
+          # Authenticate with GitHub CLI
+          echo "${{ secrets.MACHINE_USER_TOKEN }}" | gh auth login --with-token
 
-            ### Version Information
-            - Environment: ${{ steps.vars.outputs.env }}
-            - Helm Chart Version: ${{ steps.process-tag.outputs.version }}
-            - Image Tag: ${{ steps.process-tag.outputs.deploy_tag }}
-            - Git Hash: ${{ steps.process-tag.outputs.git_hash }}
+          # Create release notes file
+          cat > release_notes.md << EOF
+          ## Helm Chart Update
 
-            ### Changes
-            Updated image tags in Helm values from:
-            - Backend: `${{ steps.update_helm.outputs.old_backend_tag }}`
-            - Frontend: `${{ steps.update_helm.outputs.old_frontend_tag }}`
+          This release updates the Helm charts for the **${{ steps.vars.outputs.env }}** environment.
 
-            To:
-            - Backend: `${{ steps.update_helm.outputs.deploy_tag }}`
-            - Frontend: `${{ steps.update_helm.outputs.deploy_tag }}`
+          ### Version Information
+          - Environment: ${{ steps.vars.outputs.env }}
+          - Helm Chart Version: ${{ steps.process-tag.outputs.version }}
+          - Image Tag: ${{ steps.process-tag.outputs.deploy_tag }}
+          - Git Hash: ${{ steps.process-tag.outputs.git_hash }}
+
+          ### Changes
+          Updated image tags in Helm values from:
+          - Backend: \`${{ steps.update_helm.outputs.old_backend_tag }}\`
+          - Frontend: \`${{ steps.update_helm.outputs.old_frontend_tag }}\`
+
+          To:
+          - Backend: \`${{ steps.update_helm.outputs.deploy_tag }}\`
+          - Frontend: \`${{ steps.update_helm.outputs.deploy_tag }}\`
+          EOF
+
+          # Create the release
+          gh release create "${{ steps.process-tag.outputs.tag_name }}" \
+            --title "Release ${{ steps.process-tag.outputs.tag_name }}" \
+            --notes-file release_notes.md \
+            --generate-notes \
+            ${{ steps.vars.outputs.env == 'staging' && '--prerelease' || '' }}
+
+          echo "✅ GitHub release created successfully!"


### PR DESCRIPTION
This PR fixes the issue with GitHub release creation by using the GitHub CLI instead of the action-gh-release action. This should resolve the 'Not Found' error when creating releases.