### PR TITLE
fix: normalize environment names and use GitHub CLI for releases

### DIFF
--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -121,7 +121,17 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Helm Values File Validation"
-          VALUES_FILE="config/helm/${{ steps.vars.outputs.env }}.yaml"
+          # Normalize environment name for file paths
+          FILE_ENV="${{ steps.vars.outputs.env }}"
+          if [ "${{ steps.vars.outputs.env }}" = "stg" ]; then
+            FILE_ENV="staging"
+            echo "Normalized environment name from 'stg' to 'staging' for file path"
+          elif [ "${{ steps.vars.outputs.env }}" = "prod" ]; then
+            FILE_ENV="production"
+            echo "Normalized environment name from 'prod' to 'production' for file path"
+          fi
+
+          VALUES_FILE="config/helm/$FILE_ENV.yaml"
           if [ ! -f "$VALUES_FILE" ]; then
             echo "::error::Values file $VALUES_FILE does not exist"
             echo "Available files in config/helm/:"


### PR DESCRIPTION
This PR includes two fixes:

1. **Fix GitHub release creation**: 
   - Replaces the  action with direct GitHub CLI commands
   - Adds proper authentication using the 
   - Creates release notes files to ensure proper formatting
   - Adds better error handling and debugging

2. **Fix environment name normalization**:
   - Ensures that when the environment is 'stg', it correctly looks for 'staging.yaml' file in the config/helm directory
   - Normalizes environment names in the k8s.mk file
   - Adds proper error handling and debugging information

These changes should resolve both the 'Not Found' error when creating releases and the 'Values file config/helm/stg.yaml does not exist' error.