### PR TITLE
chore(helm): update image tags for  to

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,10 +1,10 @@
-Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.2-3ab552c**.
+Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.3-7df8fb1**.
 
 **Changes:**
-- **Target Tag:** `stg-3ab552c`
+- **Target Tag:** `stg-7df8fb1`
 - **Previous Backend Tag:** `stg-latest`
 - **Previous Frontend Tag:** `stg-latest`
 
-**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14539517318)
+**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14539702679)
 
 This PR will be automatically merged upon successful checks.


### PR DESCRIPTION
Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.3-7df8fb1**.

**Changes:**
- **Target Tag:** `stg-7df8fb1`
- **Previous Backend Tag:** `stg-latest`
- **Previous Frontend Tag:** `stg-latest`

**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14539702679)

This PR will be automatically merged upon successful checks.
