### PR TITLE
chore(helm): update image tags for  to

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,10 +1,10 @@
-Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.7-928d0b0**.
+Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.7-8dd4096**.
 
 **Changes:**
-- **Target Tag:** `stg-928d0b0`
+- **Target Tag:** `stg-8dd4096`
 - **Previous Backend Tag:** `stg-latest`
 - **Previous Frontend Tag:** `stg-latest`
 
-**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14542356363)
+**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14548727377)
 
 This PR will be automatically merged upon successful checks.


### PR DESCRIPTION
Automated update of Helm values for the **stg** environment triggered by release **vstg-0.3.7-8dd4096**.

**Changes:**
- **Target Tag:** `stg-8dd4096`
- **Previous Backend Tag:** `stg-latest`
- **Previous Frontend Tag:** `stg-latest`

**Workflow Run:** [View Run](https://github.com/datascientest-fastAPI-project-group-25/fastAPI-project-release/actions/runs/14548727377)

This PR will be automatically merged upon successful checks.
