### PR TITLE
chore(helm): update image tags for stg to stg-fbbe6fd

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.3.8-fbbe6fd**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-fbbe6fd
- **Previous Backend Tag:** stg-latest
- **Previous Frontend Tag:** stg-latest

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -7,7 +7,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-latest  # This will be updated by the CI pipeline
+  tag: stg-fbbe6fd  # This will be updated by the CI pipeline
   replicas: 1
   port: 8000
   service:
@@ -19,7 +19,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-latest  # This will be updated by the CI pipeline
+  tag: stg-fbbe6fd  # This will be updated by the CI pipeline
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md