### PR TITLE
chore(helm): update image tags for stg to stg-6c3883b

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.3.9-6c3883b**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-6c3883b
- **Previous Backend Tag:** stg-420893d
- **Previous Frontend Tag:** stg-420893d

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -7,7 +7,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-420893d
+  tag: stg-6c3883b
   replicas: 1
   port: 8000
   service:
@@ -19,7 +19,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-420893d  # This will be updated by the CI pipeline
+  tag: stg-6c3883b  # This will be updated by the CI pipeline
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md