### PR TITLE
chore(helm) Update image tags for stg to stg-68ebfda

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.5.0-68ebfda**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-68ebfda
- **Previous Backend Tag:** stg-71ce56a
- **Previous Frontend Tag:** stg-71ce56a

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-71ce56a
+  tag: stg-68ebfda
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-71ce56a  # This will be updated by the CI pipeline
+  tag: stg-68ebfda  # This will be updated by the CI pipeline
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md