### PR TITLE
chore(helm) Update image tags for stg to stg-43e5ac2

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.5.0-43e5ac2**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-43e5ac2
- **Previous Backend Tag:** stg-68ebfda
- **Previous Frontend Tag:** stg-68ebfda

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-68ebfda
+  tag: stg-43e5ac2
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-68ebfda  # This will be updated by the CI pipeline
+  tag: stg-43e5ac2  # This will be updated by the CI pipeline
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md