### PR TITLE
chore(helm) Update image tags for prod to 0.0.1

Updates image tags in Helm values for the **prod** environment based on release **v0.0.1**.

**Changes:**
- **Environment:** prod
- **Target Tag:** 0.0.1
- **Previous Backend Tag:** 1.2.3
- **Previous Frontend Tag:** 1.2.3
- **Chart Version:** 0.0.1

### DIFF
--- a/charts/fastapi/Chart.yaml
+++ b/charts/fastapi/Chart.yaml
@@ -5,10 +5,10 @@ description: A Helm chart for deploying the FastAPI application with frontend an
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.3
+version: 0.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.2.3"
+appVersion: 0.0.1
 # Dependencies
 dependencies: []
 maintainers:

--- a/config/helm/values-prod.yaml
+++ b/config/helm/values-prod.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: 1.2.3 # This will be updated by the CI pipeline
+  tag: 0.0.1 # This will be updated by the CI pipeline
   replicas: 2 # Higher replica count for prod
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: 1.2.3 # This will be updated by the CI pipeline
+  tag: 0.0.1 # This will be updated by the CI pipeline
   replicas: 2 # Higher replica count for prod
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md