### PR TITLE
chore(helm) Update image tags for stg to stg-e1fc22e

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.0.3-e1fc22e**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-e1fc22e
- **Previous Backend Tag:** stg-1bb4ca8
- **Previous Frontend Tag:** stg-1bb4ca8

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-1bb4ca8
+  tag: stg-e1fc22e
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-1bb4ca8
+  tag: stg-e1fc22e
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md