### PR TITLE
chore(helm) Update image tags for stg to stg-10ded36

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.1.0-10ded36**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-10ded36
- **Previous Backend Tag:** stg-e1fc22e
- **Previous Frontend Tag:** stg-e1fc22e

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-e1fc22e
+  tag: stg-10ded36
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-e1fc22e
+  tag: stg-10ded36
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md