### PR TITLE
chore(helm) Update image tags for stg to stg-8566de8

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.3.1-8566de8**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-8566de8
- **Previous Backend Tag:** stg-b13f2e8
- **Previous Frontend Tag:** stg-b13f2e8

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-b13f2e8
+  tag: stg-8566de8
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-b13f2e8
+  tag: stg-8566de8
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md