### PR TITLE
chore(helm) Update image tags for stg to stg-5b1a56a

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.6.0-5b1a56a**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-5b1a56a
- **Previous Backend Tag:** stg-8727308
- **Previous Frontend Tag:** stg-8727308

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -6,7 +6,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-8727308
+  tag: stg-5b1a56a
   replicas: 1
   port: 8000
   service:
@@ -17,7 +17,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-8727308
+  tag: stg-5b1a56a
   replicas: 1
   port: 80
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md