### PR TITLE
chore(helm) Update image tags for stg to stg-97f95fa

Updates image tags in Helm values for the **stg** environment based on release **vstg-0.7.0-97f95fa**.

**Changes:**
- **Environment:** stg
- **Target Tag:** stg-97f95fa
- **Previous Backend Tag:** stg-5b1a56a
- **Previous Frontend Tag:** stg-5b1a56a

### DIFF
--- a/config/helm/values-stg.yaml
+++ b/config/helm/values-stg.yaml
@@ -9,7 +9,7 @@ app:
 backend:
   name: backend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/backend
-  tag: stg-5b1a56a
+  tag: stg-97f95fa
   port: 8000
   replicas: 1
   service:
@@ -20,7 +20,7 @@ backend:
 frontend:
   name: frontend
   image: ghcr.io/datascientest-fastapi-project-group-25/fastapi-project-app/frontend
-  tag: stg-5b1a56a
+  tag: stg-97f95fa
   port: 80
   replicas: 1
   service:


### PR DESCRIPTION
✅ PR body content written to pr_body.md